### PR TITLE
Add membership within the extension instead of core

### DIFF
--- a/membershiprenewalcontrol.php
+++ b/membershiprenewalcontrol.php
@@ -123,14 +123,7 @@ function membershiprenewalcontrol_civicrm_pre($op, $objectName, &$id, &$params) 
       'return' => array("name"),
     ));
 
-    // Expired, Cancelled, Resigned, Moved interstate
-    // Suspended", "Application Rejected", "Member Expelled", and "Application Withdrawn"
-    //~ $expiredStatusID = 4;
-
-    //~ $nonRenewableStatuses = array($expiredStatusID, 6 , 10, 12, 14, 15, 16, 17);
-
     $nonRenewableStatuses = array();
-
     foreach ($membershipStatus['values'] as $key => $status) {
       if (in_array($status['name'],
         array('Expired', 'Cancelled', 'Resigned', 'Moved interstate', 'Suspended', 'Application Rejected', 'Member Expelled', 'Application Withdrawn'))
@@ -152,6 +145,12 @@ function membershiprenewalcontrol_civicrm_pre($op, $objectName, &$id, &$params) 
         && strtotime($existingMembership['end_date']) > strtotime('1 year ago')) {
         return;
       }
+      $contriId = CRM_Member_BAO_Membership::getMembershipContributionId($params['id']);
+      $totalAmount = civicrm_api3('Contribution', 'getsingle', array(
+        'sequential' => 1,
+        'return' => array("total_amount"),
+        'id' => $contriId,
+      ));
       $newStatus = civicrm_api3('membership_status', 'getvalue', array('name'=> 'new', 'return' => 'id'));
       unset($params['id'], $params['membership_id']);
       $id = NULL;
@@ -161,6 +160,10 @@ function membershiprenewalcontrol_civicrm_pre($op, $objectName, &$id, &$params) 
 
       $newMembership = CRM_Member_BAO_Membership::add($params);
       $memInfo = array_merge($params, array('membership_id' => $newMembership->id));
+      //Ensure total_amount has a value.
+      if (empty($memInfo['total_amount'])) {
+        $memInfo['total_amount'] = $totalAmount['total_amount'];
+      }
       $params['contribution'] = CRM_Member_BAO_Membership::recordMembershipContribution($memInfo);
       $params['id'] = $params['membership_id'] = $id = $newMembership->id;
       unset($params['contribution_status_id']);

--- a/membershiprenewalcontrol.php
+++ b/membershiprenewalcontrol.php
@@ -157,6 +157,13 @@ function membershiprenewalcontrol_civicrm_pre($op, $objectName, &$id, &$params) 
       $id = NULL;
       $params['join_date'] = $params['membership_start_date'] = $params['start_date'];
       $params['status_id'] = $newStatus;
+      $params['contribution_status_id'] = 1;
+
+      $newMembership = CRM_Member_BAO_Membership::add($params);
+      $memInfo = array_merge($params, array('membership_id' => $newMembership->id));
+      $params['contribution'] = CRM_Member_BAO_Membership::recordMembershipContribution($memInfo);
+      $params['id'] = $params['membership_id'] = $id = $newMembership->id;
+      unset($params['contribution_status_id']);
     }
     //Create new Pending membership in case of renewal and completetransaction is yet to be executed.
     elseif (!empty($params['contribution']) && $params['contribution']->contribution_status_id == $pendingStatus && in_array($existingMembership['status_id'], $nonRenewableStatuses)) {


### PR DESCRIPTION
When creating a new record for an expired membership, this ext [deletes the old line item](https://github.com/civicrm/civicrm-core/blob/master/CRM/Member/BAO/Membership.php#L368) of existing membership + doesn't creates a line item of renewal contribution - rm13360.

This change creates the new membership and its payment from the ext itself and passes the new id for renewal so that the process remains the same within core. 

UPDATE: 2nd commit considers the `total_amount` of previous existing/expired membership if it not present in recording the current membership.