### PR TITLE
fix for renew membership when contribution is pay later and status is…

### DIFF
--- a/membershiprenewalcontrol.php
+++ b/membershiprenewalcontrol.php
@@ -153,8 +153,7 @@ function membershiprenewalcontrol_civicrm_pre($op, $objectName, &$id, &$params) 
         return;
       }
       $newStatus = civicrm_api3('membership_status', 'getvalue', array('name'=> 'new', 'return' => 'id'));
-      unset($params['id'], $params['membership_id']);
-      $id = NULL;
+      $id = $params['id'] = $params['membership_id'] = NULL;
       $params['join_date'] = $params['membership_start_date'] = $params['start_date'];
       $params['status_id'] = $newStatus;
     }
@@ -166,8 +165,7 @@ function membershiprenewalcontrol_civicrm_pre($op, $objectName, &$id, &$params) 
         'label' => 'Pending',
         'return' => 'id',
       ));
-      unset($params['id'], $params['membership_id']);
-      $id = NULL;
+      $id = $params['id'] = $params['membership_id'] = NULL;
     }
   }
 }


### PR DESCRIPTION
… updated to completed on backend
Before:
if you use the front end contribution form to renew a membership, and use the pay later option, a contribution with status pending is created, and no membership updated. Then as an admin edit the contribution that is created, and change the status from 'Pending' to 'Completed'. The extension does not create a new membership, instead the existing one is updated, because $params['id'] or $params['membership_id'] is not present....and $id is not passed by reference or at least not updateable...
in version 4.6 see 1700-1712 
https://github.com/civicrm/civicrm-core/blob/4.6/CRM/Contribute/BAO/Contribution.php#L1711

After:
Using pay later option to renew membership, and updating contribution created changing status from 'Pending' to 'Completed'
A new membership record is generated instead of updating the existing one. 

Not sure if this would be a fix for 4.6 only, or if it applies to 4.7/5.x as well...

But it seems the code there IS the same
https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/BAO/Contribution.php#L1953

Thoughts on setting $params['id'] and $params['membership_id'] to NULL instead of unsetting?